### PR TITLE
Handle Python INDI drivers; improve resuctrl handling of INDI drivers

### DIFF
--- a/apps/resurrector/redirect_prototype.cpp
+++ b/apps/resurrector/redirect_prototype.cpp
@@ -227,9 +227,10 @@ stdout_stderr_redirect(std::string devicename)
     };
 
     errno = 0;            // Ensure there is no current error
+    int step{0};
 
     // Loop over those steps, exit loop early if errno becomes non-zero
-    for (int step = S_BUILD_SUBDIR
+    for (step = S_BUILD_SUBDIR
         ; !errno && step < S_LAST
         ; ++step
         )
@@ -250,6 +251,14 @@ stdout_stderr_redirect(std::string devicename)
         case S_CLOS_FSTDXXX: close(fstdxxx); break;
         default: break;
         }
+    }
+    if (step!=S_LAST)
+    {
+        fprintf(stderr,"ERROR:  stdout_stderr_redirect('%s')"
+                       "; lasttep=%d"
+                       "; errno=%d[%s]\n"
+               , devicename.c_str(), step, errno, strerror(errno)
+               );
     }
 } // void stdout_stderr_redirect(std::string devicename)
 

--- a/apps/resurrector/resuctrl
+++ b/apps/resurrector/resuctrl
@@ -56,6 +56,7 @@ function verb_shutdown {
   command="kill -USR1 $ripid"
   resu_success "$command"
   $command
+  sleep 3  ### To allow any STDERR/STDOUT of resurrector_indi to display
 }
 
 ########################################################################
@@ -101,6 +102,7 @@ function verb_start {
   command="kill -USR2 $ripid"
   resu_success "$command"
   $command
+  sleep 3  ### To allow any STDERR/STDOUT of resurrector_indi to display
 }
 
 ########################################################################
@@ -133,10 +135,11 @@ function verb_stop {
   command="kill -USR2 $ripid"
   resu_success "$command"
   $command
+  sleep 3  ### To allow any STDERR/STDOUT of resurrector_indi to display
 }
 
 ########################################################################
-### Trigger resurrector to stop and start Heaxbeaters before they expire
+### Trigger resurrector to stop and start Hexbeaters before their expiry
 function verb_defib {
 
   [ "$procnames" ] \
@@ -358,14 +361,47 @@ function proclist_path {
 ### Send the PID of the first process running resurrector_indi to stdout
 function resurrector_indi_pid {
 
-  lsof +c 0 | \grep 'txt.*/resurrector_indi$' \
+  ### Search for resurrector_indi executable via lsof command output in
+  ### several places, taking the first place that yields a match:
+  ### 1) look first in same directory as this script,
+  ### 2) then under MagAOX binaries' directory (/opt/MagAOX/bin/),
+  ### 3) then under MagAOX sources' directory (/opt/MagAOX/source),
+  ### 3) then under /usr/local/bin/
+  ### 4) finally anywhere under root (/), which is slow (~0.5Mfiles+)
+  ###
+  ### Options for lsof (LiSt Open Files):
+  ### -l       Do not convert UIDs to usernames
+  ### -n       Do not convert network numbers to host names
+  ### -w       Turn off warnings (lsof cannot check user filesystems)
+  ### +D DIR   Look for all open files under directory DIR
+
+  for P in "$(dirname "$0")/resurrector_indi" \
+           "${opt_magaox}/bin/" "${opt_magaox}/source/" \
+           "/usr/local/bin/" "/" \
+  ; do
+     [ "$P" == "/" ] && slow_warning
+     [ "$P" ] && [ -d "$P" ] && D="+D" || D=""
+     lsof -lnw $D "$P" | \grep 'txt.*/resurrector_indi$' && break
+  done \
   | while read ri pid user txt reg device size_off node exe cruft ; do
       [ "$txt" == "txt" ] \
       && [ "$(basename "$exe")" == "resurrector_indi" ] \
       && [ "$pid" ] \
       && echo $pid | grep '^[1-9][0-9]*$' \
       && break
-    done | \grep .               ### Return failure if nothing was found
+    done | \grep .              ### Returns failure if nothing was found
+}
+
+########################################################################
+### Warning message for function resurrector_indi_pid above
+function slow_warning {
+  cat 1>&2 << EoFwarning
+$YELLOW_SEQ
+A running resurrector_indi binary was not found where expected; trying
+again in all filesystems, but it may take as much as a minute longer;
+press ^C if there is no resurrector_indi currently active.$RESET_SEQ
+EoFwarning
+  return 0
 }
 
 ########################################################################
@@ -387,7 +423,7 @@ function find_resu_hexbeat_pipe {
   ri="resurrector_indi"
 
   ### List all processes that have that pipe open; find resurrector_indi
-  lsof +c 0  "$hbpath" \
+  lsof -lnw "$hbpath" \
   | while read cmd pid user fd type dev sizeoff mode path cruft ; do
 
       ### ripid=... => fails if resurrector_indi is not currently active
@@ -421,7 +457,7 @@ function find_device_hexbeat_pipe {
   ri="resurrector_indi"
 
   ### List all processes that have that pipe open; skip resurrector_indi
-  lsof +c 0  "$hbpath" \
+  lsof -lnw "$hbpath" \
   | while read cmd pid user fd type dev sizeoff mode path cruft ; do
 
       ### ripid=... => retrieves the PID of the resurrector_indi process


### PR DESCRIPTION
resurrector/HexbeatMonitor.hpp
- Handle INDI drivers that are python scripts
- /proc/[PID]/cmdline file contains four command line tokens instead of three i.e. [python,exe,-n,drivername] instead of [exe,-n,drivername]

resurrector/redirect_prototype.cpp
- Add error logging to output redirect

resurrector/resuctrl
- Handle INDI drivers that are python scripts
- Clean- and speed-up search for resurrector PID via lsof