### PR TITLE
Add zlib compression to inter-INDI server comms

### DIFF
--- a/INDI/INDI/Makefile
+++ b/INDI/INDI/Makefile
@@ -6,7 +6,7 @@ include $(SELF_DIR)/../../Make/common.mk
 all: indiserver getINDI setINDI evalINDI
 
 indiserver: strcat_varargs.c strcat_varargs.h open_named_fifo.c open_named_fifo.h config.h indiapi.h indidevapi.h fq.c fq.h libs/lilxml.h libs/lilxml.c indiserver.c
-	$(CC) $(CFLAGS) -DGIT_TAG_STRING='"$(shell git describe --tags)"' -g -o indiserver -Ilibs indiserver.c strcat_varargs.c open_named_fifo.c fq.c libs/lilxml.c
+	$(CC) $(CFLAGS) -DGIT_TAG_STRING='"$(shell git describe --tags)"' -g -o indiserver -Ilibs $(shell pkg-config --cflags zlib) indiserver.c strcat_varargs.c open_named_fifo.c fq.c libs/lilxml.c $(shell pkg-config --libs zlib)
 
 old.indiserver: strcat_varargs.h strcat_varargs.c pipe_wrapper.h pipe_wrapper.c indiapi.h fq.h fq.c indiserver.c
 	$(CC) $(CFLAGS) -g -o indiserver -I../liblilxml  indiserver.c pipe_wrapper.c strcat_varargs.c fq.c ../liblilxml/liblilxml.a -lpthread

--- a/apps/xindiserver/xindiserver.hpp
+++ b/apps/xindiserver/xindiserver.hpp
@@ -127,6 +127,7 @@ protected:
    int indiserver_p {-1}; ///< The indiserver port (passed to indiserver)
    int indiserver_v {-1}; ///< The indiserver verbosity (passed to indiserver)
    bool indiserver_x {false}; ///< The indiserver terminate after last exit flag (passed to indiserver)
+   bool indiserver_z {false}; ///< The inter-indiserver zlib compression flag
    
    std::string m_driverFIFOPath; ///< The path to the local drivers' FIFOs directory
    std::vector<std::string> m_local; ///< List of local drivers passed in by config
@@ -250,6 +251,7 @@ void xindiserver::setupConfig()
    config.add("indiserver.p", "p", "", argType::Required, "indiserver", "p", false,  "int", "indiserver: alternate IP port, default 7624");
    config.add("indiserver.v", "v", "", argType::True, "indiserver", "v", false,  "int", "indiserver: log verbosity, -v, -vv or -vvv");
    config.add("indiserver.x", "x", "", argType::True, "indiserver", "x", false,  "bool", "exit after last client disconnects -- FOR PROFILING ONLY");
+   config.add("indiserver.z", "z", "", argType::Required, "indiserver", "z", false,  "bool", "Whether to use zlib compression between INDI servers");
    
    config.add("local.drivers","L", "local.drivers" , argType::Required, "local", "drivers", false,  "vector string", "List of local drivers to start.");
    config.add("remote.drivers","R", "remote.drivers" , argType::Required, "remote", "drivers", false,  "vector string", "List of remote drivers to start, in the form of name@tunnel, where tunnel is the name of a tunnel specified in sshTunnels.conf.");
@@ -282,6 +284,7 @@ void xindiserver::loadConfig()
    }
    
    config(indiserver_x, "indiserver.x");
+   config(indiserver_z, "indiserver.z");
    
    config(m_local, "local.drivers");// May be empty if [indiserver_ctrl_fifo] is configured to match [indiserver.f]
    config(m_remote, "remote.drivers");
@@ -331,6 +334,8 @@ int xindiserver::constructIndiserverCommand( std::vector<std::string> & indiserv
       
       // The indiserver terminate after last exit flag
       if(indiserver_x == true) indiserverCommand.push_back("-x");
+
+      if(indiserver_z == true) indiserverCommand.push_back("-z");
    }
    catch(...)
    {

--- a/setup/20240729_manual_steps.txt
+++ b/setup/20240729_manual_steps.txt
@@ -1,0 +1,56 @@
+########################################################################
+### On primary Ubuntu 22.04 (see MULTIPASS below)
+########################################################################
+
+####################################
+### Some SUDO actions:  update; man dirs; /opt/MagAOX; MAGAOX_ROLE
+
+  sudo su -
+    apt-get update                                        ### Short wait
+    mkdir -p /usr/local/share/man/man{1,2,3,4,5,6,7,8,9}
+    mkdir -p /opt/MagAOX
+    chown :ubuntu /opt/MagAOX
+    chmod u+sX,g+wsX /opt/MagAOX
+    echo export MAGAOX_ROLE=vm | tee    /etc/profile.d/magaox_role.sh
+    exit
+
+### End SUDO actions
+####################################
+
+  source /etc/profile.d/magaox_role.sh
+
+  mkdir ~/githubalt
+  cd ~/githubalt
+  git clone -b resurrector-zlibINDI https://github.com/drbitboy/MagAOX.git
+  git clone https://github.com/drbitboy/magao-x-config.git config
+
+  cd ~/githubalt/MagAOX/setup/
+
+  ######################################################################
+  bash -lx provision.sh                               ### Very long wait
+  ######################################################################
+
+  mkfifo /opt/MagAOX/drivers/fifos/indiserver.ctrl
+
+  bash -l    ### Re-read BASH environment e.g. MKLROOT
+
+  cd /opt/MagAOX/source/MagAOX/utils/resurrector_indi/
+  make clean all install
+  resuctrl startup
+
+########################################################################
+### MULTIPASS:  On Windows or WSL; for Linux, drop the .exe
+########################################################################
+
+### Stop, delete and purge existing primary multipass.exe VM
+   multipass.exe stop primary
+   multipass.exe delete primary
+   multipass.exe purge
+
+### Create new primary multipass.exe VM
+   multipass.exe launch -n primary 22.04                 ### Medium wait
+   multipass.exe stop primary
+   multipass.exe set local.primary.disk=20GiB
+   multipass.exe set local.primary.cpus=4
+   multipass.exe start primary                             ### Long wait
+

--- a/setup/provision.sh
+++ b/setup/provision.sh
@@ -160,7 +160,9 @@ fi
 ## Build third-party dependencies under /opt/MagAOX/vendor
 cd /opt/MagAOX/vendor
 sudo -H bash -l "$DIR/steps/install_rclone.sh" || exit 1
-bash -l "$DIR/steps/install_openblas.sh" || exit 1
+[ -r "$DIR/steps/install_openblas.inhibit" ] \
+|| ( bash -l "$DIR/steps/install_openblas.sh" && touch "$DIR/steps/install_openblas.inhibit" ) \
+|| exit 1
 if [[ $MAGAOX_ROLE == RTC || $MAGAOX_ROLE == ICC || $MAGAOX_ROLE == AOC || $MAGAOX_ROLE == TIC ]]; then
     bash -l "$DIR/steps/install_cuda_rocky_9.sh" || exit_with_error "CUDA install failed"
 fi
@@ -170,6 +172,7 @@ sudo -H bash -l "$DIR/steps/install_eigen.sh" || exit 1
 sudo -H bash -l "$DIR/steps/install_zeromq.sh" || exit 1
 sudo -H bash -l "$DIR/steps/install_cppzmq.sh" || exit 1
 sudo -H bash -l "$DIR/steps/install_flatbuffers.sh" || exit 1
+sudo -H bash -l "$DIR/steps/install_zlib-drbitboy.sh" || exit 1
 if [[ $MAGAOX_ROLE == AOC ]]; then
     sudo -H bash -l "$DIR/steps/install_lego.sh"
 fi

--- a/setup/steps/install_zlib-drbitboy.sh
+++ b/setup/steps/install_zlib-drbitboy.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+source $DIR/../_common.sh
+set -euo pipefail
+ZLIB_COMMIT="develop-20240718-drbitboy"
+#
+# xrif streaming compression library
+#
+orgname=drbitboy
+reponame=zlib-drbitboy
+parentdir=/opt/MagAOX/vendor
+destdir=""
+clone_or_update_and_cd $orgname $reponame $parentdir $destdir
+git checkout $ZLIB_COMMIT
+make distclean && ./configure && make test && sudo make install


### PR DESCRIPTION
INDI/INDI/indiserver.c
- Add gzFile members to struct strDrvInfo, for sockets
- Open and use zlib reader (gzFile) for remote drivers and clients
- Make connected sockets non-blocking
- Implement GZ writes, GZ write check for clients
- Have upstream server tell downstream server that downstream server can use compressed writes (gzwrite)
- Refactor driver and client close(2) calls to closeIndiconnection()
- Update, improve, and/or fix, comments and logging
- refactor close(2) calls

- Other fixes not directly related to zlib:
  - Minor justification changes
  - Reset found device flag in indiserver.c
  - Minor fix to eliminate segfault in INDI server when driver, which does not yet have a device name, stopped in newFIFO

Add setup and installation of zlib-drbitboy
Add new manual steps file
Allow OpenBLAS installation to be inhibited