### PR TITLE
Replace INDI server fork with calls to INDI server

### DIFF
--- a/INDI/INDI/fq.c
+++ b/INDI/INDI/fq.c
@@ -72,7 +72,7 @@ FQ *newFQ(int grow)
 {
     FQ *q = (FQ *)(*fqmalloc)(sizeof(FQ));
     memset(q, 0, sizeof(FQ));
-    q->q    = (*fqmalloc)(1); /* seed for realloc */
+    q->q    = (void**)(*fqmalloc)(1); /* seed for realloc */
     q->grow = grow > 0 ? grow : 1;
     return (q);
 }
@@ -147,7 +147,7 @@ static void chkFQ(FQ *q)
 
     /* realloc to minimum number of grow-sized chunks required */
     q->nmem = q->grow * (q->head / q->grow + 1);
-    q->q    = (*fqrealloc)(q->q, q->nmem * sizeof(void *));
+    q->q    = (void**)(*fqrealloc)(q->q, q->nmem * sizeof(void *));
 }
 
 #if defined(TEST_FQ)

--- a/apps/xindiserver/Makefile
+++ b/apps/xindiserver/Makefile
@@ -1,7 +1,10 @@
 
 allall: all 
 
+CPPFLAGS   += -DGIT_TAG_STRING='"$(shell git describe --tags)"'
+INCLUDES   += -I../../INDI/liblilxml
+LDLIBS     += $(shell pkg-config --libs zlib)
 OTHER_HEADERS=
-TARGET=xindiserver
+OTHER_OBJS  = callable_indiserver.o
+TARGET      = xindiserver
 include ../../Make/magAOXApp.mk
-

--- a/apps/xindiserver/callable_indiserver.c
+++ b/apps/xindiserver/callable_indiserver.c
@@ -1,0 +1,5 @@
+#include "../../INDI/INDI/fq.c"
+#include "../../INDI/INDI/strcat_varargs.c"
+#include "../../INDI/INDI/open_named_fifo.c"
+#define __INDISERVER_MAIN__ callable_indiserver
+#include "../../INDI/INDI/indiserver.c"

--- a/libMagAOX/app/MagAOXApp.hpp
+++ b/libMagAOX/app/MagAOXApp.hpp
@@ -1762,6 +1762,13 @@ void MagAOXApp<_useINDI>::_handlerSigTerm( int signum,
    m_self->handlerSigTerm(signum, siginf, ucont);
 }
 
+static std::string
+sigabbrev(int sig)
+{
+    char* p = (char*) sigabbrev_np(sig);
+    return std::string("SIG") + (p ? p : "<unknown>");
+}
+
 template<bool _useINDI>
 void MagAOXApp<_useINDI>::handlerSigTerm( int signum,
                                           siginfo_t *siginf __attribute__((unused)),
@@ -1770,6 +1777,7 @@ void MagAOXApp<_useINDI>::handlerSigTerm( int signum,
 {
    m_shutdown = 1;
 
+#  if 0
    std::string signame;
    switch(signum)
    {
@@ -1783,11 +1791,12 @@ void MagAOXApp<_useINDI>::handlerSigTerm( int signum,
          signame = "SIGQUIT";
          break;
       default:
-         signame = "OTHER";
+         signame = std::string("SIG") + "OTHER";
    }
+#  endif//0
 
    std::string logss = "Caught signal ";
-   logss += signame;
+   logss += sigabbrev(signum); // signame;
    logss += ". Shutting down.";
 
    std::cerr << "\n" << logss << std::endl;


### PR DESCRIPTION
/INDI/INDI/indiserver.c
/INDI/INDI/fq.c
- Routine main(...) in indiserver.c becomes callable_indiserver(...)
- Call indiRun() from xindiserver::appLogic()
- Change default loop pause to 0.1s
- remove some unused code
- remove trailing whitespace
- Link callable INDI server into xindiserver
- clean up alloc and other statements so they can be compiled by g++

/libMagAOX/app/MagAOXApp.hpp
- Use sigabbrev_np to get signal name